### PR TITLE
Fix filter construction for field names with uppercase characters.

### DIFF
--- a/rest_framework_filterdsl/filters.py
+++ b/rest_framework_filterdsl/filters.py
@@ -92,7 +92,7 @@ class FilterDSLBackend(filters.BaseFilterBackend):
                     raise BadQuery("Unsupported operator: \"{0}\"".format(op.op))
 
                 f = Q(**{
-                    "{0}__{1}".format(left.name, model_op): right
+                    "{0}__{1}".format(left.value, model_op): right
                 })
                 if negate:
                     f = ~f


### PR DESCRIPTION
It seems like the `.name` property contains the lowercased version of the field name, and Django query filters require the version of the field with the correct casing (which is in `.value`).